### PR TITLE
Stop publishing empty package, use CDN in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ TypeScript libraries for nodecore repo.
 
 **Node:**
 ```bash
+# Yarn
 yarn add @veriblock/nodecore-js
+
+# NPM
+npm install --save @veriblock/nodecore-js
 ```
 
 **Browser:**
-```bash
-git clone https://github.com/VeriBlock/nodecore-js
-yarn
-yarn build:browser
+```html
+<scrit src="https://unpkg.com/@veriblock/nodecore-js/build/browser.veriblock.js"></script>
 ```
-Bundle path: `./build/browser.veriblock.js`.
+
 All functions start with `VeriBlock`. Example: 
 ```
 var kp = VeriBlock.KeyPair.generate()

--- a/package.json
+++ b/package.json
@@ -1,11 +1,12 @@
 {
   "name": "@veriblock/nodecore-js",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "JavaScript/TypeScript libraries for veriblock nodecore repo.",
   "main": "./build/node/src/index.js",
   "types": "./build/node/src/index.d.ts",
   "files": [
-    "./build/node/src"
+    "/build/node/src/**/*",
+    "/build/browser.veriblock.js"
   ],
   "private": false,
   "scripts": {
@@ -22,7 +23,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "pretest": "npm run compile",
-    "posttest": "npm run check"
+    "posttest": "npm run check",
+    "prepare": "npm run build && npm run build:browser"
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
Right now an empty npm package is published. In this PR:

* `"files"` property in `package.json` is fixed to actually include files
* `"prepare"` [magic script](https://docs.npmjs.com/misc/scripts) was added
* use [CDN](https://unpkg.com/)  in browser examples. (better than cloning whole repo imo)

I have **NOT** published the changes to NPM yet, will do after this gets reviewed and merged