### PR TITLE
NCS-461 - Make PrivateKey constructor from nodecore-js to recognize nodecore dumped privatekey

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [12.x, 14.x, 16.x]
       fail-fast: false
     env:
       CI: true

--- a/packages/core/src/cryptography.ts
+++ b/packages/core/src/cryptography.ts
@@ -29,6 +29,12 @@ export const PRIVKEY_ASN1_PREFIX = Buffer.from(
   'hex'
 );
 
+// prefix which nodecore adds to the begginning of the string
+export const NC_PRIVKEY_PREFIX = Buffer.from(
+  '40',
+  'hex'
+);
+
 export class PublicKey {
   // stores asn1 encoded public key as [pubkey asn1 prefix + 0x04 + x + y]
   // 88 bytes in total
@@ -131,6 +137,16 @@ export class PrivateKey {
         .compare(PRIVKEY_ASN1_PREFIX) === 0
     ) {
       this._full = buffer;
+    } else if (
+      buffer.length === 153 &&
+      buffer
+        .slice(0, NC_PRIVKEY_PREFIX.length)
+        .compare(NC_PRIVKEY_PREFIX) === 0 &&
+      buffer
+        .slice(1, PRIVKEY_ASN1_PREFIX.length + NC_PRIVKEY_PREFIX.length)
+        .compare(PRIVKEY_ASN1_PREFIX) === 0
+    ) {
+      this._full = buffer.slice(1, PRIVKEY_ASN1_PREFIX.length + NC_PRIVKEY_PREFIX.length + 32);
     } else {
       throw new Error('unknown private key format');
     }

--- a/packages/core/src/cryptography.ts
+++ b/packages/core/src/cryptography.ts
@@ -139,9 +139,7 @@ export class PrivateKey {
       this._full = buffer;
     } else if (
       buffer.length === 153 &&
-      buffer
-        .slice(0, NC_PRIVKEY_PREFIX.length)
-        .compare(NC_PRIVKEY_PREFIX) === 0 &&
+      buffer[0] === 0x40 &&
       buffer
         .slice(1, PRIVKEY_ASN1_PREFIX.length + NC_PRIVKEY_PREFIX.length)
         .compare(PRIVKEY_ASN1_PREFIX) === 0

--- a/packages/core/src/cryptography.ts
+++ b/packages/core/src/cryptography.ts
@@ -29,12 +29,6 @@ export const PRIVKEY_ASN1_PREFIX = Buffer.from(
   'hex'
 );
 
-// prefix which nodecore adds to the begginning of the string
-export const NC_PRIVKEY_PREFIX = Buffer.from(
-  '40',
-  'hex'
-);
-
 export class PublicKey {
   // stores asn1 encoded public key as [pubkey asn1 prefix + 0x04 + x + y]
   // 88 bytes in total
@@ -141,10 +135,10 @@ export class PrivateKey {
       buffer.length === 153 &&
       buffer[0] === 0x40 &&
       buffer
-        .slice(1, PRIVKEY_ASN1_PREFIX.length + NC_PRIVKEY_PREFIX.length)
+        .slice(1, PRIVKEY_ASN1_PREFIX.length + 1)
         .compare(PRIVKEY_ASN1_PREFIX) === 0
     ) {
-      this._full = buffer.slice(1, PRIVKEY_ASN1_PREFIX.length + NC_PRIVKEY_PREFIX.length + 32);
+      this._full = buffer.slice(1, PRIVKEY_ASN1_PREFIX.length + 1 + 32);
     } else {
       throw new Error('unknown private key format');
     }


### PR DESCRIPTION
NCS-461 - Make PrivateKey constructor from nodecore-js to recognize nodecore dumped privatekey